### PR TITLE
fix(ci): add manual release path and major bump detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,27 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type for manual release'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      use_current_version:
+        description: 'Skip version bump and publish the version already set in composer.json'
+        required: false
+        default: false
+        type: boolean
+      prerelease:
+        description: 'Mark GitHub release as prerelease'
+        required: false
+        default: false
+        type: boolean
   pull_request:
     types: [closed]
     branches:
@@ -8,7 +29,7 @@ on:
       - master
 
 concurrency:
-  group: release-${{ github.event.pull_request.base.ref }}
+  group: release-${{ github.event.pull_request.base.ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:
@@ -18,13 +39,13 @@ jobs:
   release:
     name: 🚀 Release
     environment: ci
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -35,15 +56,19 @@ jobs:
       - name: Skip when PR is already released
         id: already_released
         run: |
-          if git log --oneline --grep="(pr #${{ github.event.pull_request.number }})" -n 1 | grep -q "chore(release):"; then
-            echo "value=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            if git log --oneline --grep="(pr #${{ github.event.pull_request.number }})" -n 1 | grep -q "chore(release):"; then
+              echo "value=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "value=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
-      - name: Determine and apply version bump
+      - name: Determine and apply version bump (from PR metadata)
         id: release_meta
-        if: steps.already_released.outputs.value != 'true'
+        if: github.event_name == 'pull_request' && steps.already_released.outputs.value != 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -55,18 +80,48 @@ jobs:
             --body-file "$PR_BODY_FILE" \
             --output "$GITHUB_OUTPUT"
 
+      - name: Determine and apply version bump (manual)
+        id: release_meta_manual
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          php scripts/release/bump_version.php \
+            --manual-bump "${{ github.event.inputs.version_bump }}" \
+            --use-current-version "${{ github.event.inputs.use_current_version }}" \
+            --output "$GITHUB_OUTPUT"
+
+      - name: Consolidate release metadata
+        id: release_meta_final
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_release=${{ steps.release_meta_manual.outputs.should_release }}" >> "$GITHUB_OUTPUT"
+            echo "bump=${{ steps.release_meta_manual.outputs.bump }}" >> "$GITHUB_OUTPUT"
+            echo "previous_version=${{ steps.release_meta_manual.outputs.previous_version }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ steps.release_meta_manual.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ steps.release_meta_manual.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=${{ steps.release_meta.outputs.should_release }}" >> "$GITHUB_OUTPUT"
+            echo "bump=${{ steps.release_meta.outputs.bump }}" >> "$GITHUB_OUTPUT"
+            echo "previous_version=${{ steps.release_meta.outputs.previous_version }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ steps.release_meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ steps.release_meta.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Stop when PR does not require release
-        if: steps.already_released.outputs.value == 'true' || steps.release_meta.outputs.should_release != 'true'
+        if: steps.already_released.outputs.value == 'true' || steps.release_meta_final.outputs.should_release != 'true'
         run: |
           if [ "${{ steps.already_released.outputs.value }}" = "true" ]; then
             echo "PR #${{ github.event.pull_request.number }} is already released; skipping."
             exit 0
           fi
-          echo "No release type found in PR title; skipping."
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual release was not requested; skipping."
+          else
+            echo "No release type found in PR title/body; skipping."
+          fi
           exit 0
 
       - name: Commit version files
-        if: steps.already_released.outputs.value != 'true' && steps.release_meta.outputs.should_release == 'true'
+        if: steps.already_released.outputs.value != 'true' && steps.release_meta_final.outputs.should_release == 'true' && github.event.inputs.use_current_version != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -75,32 +130,39 @@ jobs:
             echo "No version changes to commit."
             exit 0
           fi
-          git commit -m "chore(release): v${{ steps.release_meta.outputs.version }} (pr #${{ github.event.pull_request.number }})"
-          git push origin "HEAD:${{ github.event.pull_request.base.ref }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            git commit -m "chore(release): v${{ steps.release_meta_final.outputs.version }} (manual)"
+            git push origin "HEAD:${{ github.ref_name }}"
+          else
+            git commit -m "chore(release): v${{ steps.release_meta_final.outputs.version }} (pr #${{ github.event.pull_request.number }})"
+            git push origin "HEAD:${{ github.event.pull_request.base.ref }}"
+          fi
 
       - name: Create release tag
-        if: steps.already_released.outputs.value != 'true' && steps.release_meta.outputs.should_release == 'true'
+        if: steps.already_released.outputs.value != 'true' && steps.release_meta_final.outputs.should_release == 'true'
         run: |
-          git tag "${{ steps.release_meta.outputs.tag }}"
-          git push origin "${{ steps.release_meta.outputs.tag }}"
+          git tag "${{ steps.release_meta_final.outputs.tag }}"
+          git push origin "${{ steps.release_meta_final.outputs.tag }}"
 
       - name: Create release on GitHub
-        if: steps.already_released.outputs.value != 'true' && steps.release_meta.outputs.should_release == 'true'
+        if: steps.already_released.outputs.value != 'true' && steps.release_meta_final.outputs.should_release == 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.release_meta.outputs.tag }}
+          tag: ${{ steps.release_meta_final.outputs.tag }}
+          prerelease: ${{ github.event.inputs.prerelease == 'true' }}
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            Release v${{ steps.release_meta.outputs.version }}
+            Release v${{ steps.release_meta_final.outputs.version }}
 
-            - Bump type: `${{ steps.release_meta.outputs.bump }}`
-            - Previous: `${{ steps.release_meta.outputs.previous_version }}`
-            - Next: `${{ steps.release_meta.outputs.version }}`
+            - Bump type: `${{ steps.release_meta_final.outputs.bump }}`
+            - Previous: `${{ steps.release_meta_final.outputs.previous_version }}`
+            - Next: `${{ steps.release_meta_final.outputs.version }}`
+            - Trigger: `${{ github.event_name }}`
 
-            Install with: `composer require getstream/getstream-php:^${{ steps.release_meta.outputs.version }}`
+            Install with: `composer require getstream/getstream-php:^${{ steps.release_meta_final.outputs.version }}`
 
       - name: Update Packagist
-        if: steps.already_released.outputs.value != 'true' && steps.release_meta.outputs.should_release == 'true'
+        if: steps.already_released.outputs.value != 'true' && steps.release_meta_final.outputs.should_release == 'true'
         env:
           PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
           PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,10 @@ jobs:
       - name: Create release tag
         if: steps.already_released.outputs.value != 'true' && steps.release_meta_final.outputs.should_release == 'true'
         run: |
+          if git rev-parse -q --verify "refs/tags/${{ steps.release_meta_final.outputs.tag }}" >/dev/null; then
+            echo "Tag ${{ steps.release_meta_final.outputs.tag }} already exists; skipping tag creation."
+            exit 0
+          fi
           git tag "${{ steps.release_meta_final.outputs.tag }}"
           git push origin "${{ steps.release_meta_final.outputs.tag }}"
 
@@ -149,6 +153,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.release_meta_final.outputs.tag }}
+          skipIfReleaseExists: true
           prerelease: ${{ github.event.inputs.prerelease == 'true' }}
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/scripts/release/bump_version.php
+++ b/scripts/release/bump_version.php
@@ -64,7 +64,10 @@ function determineBumpType(string $title, string $body): string
     $title = trim($title);
     $body = trim($body);
 
-    if (preg_match('/BREAKING[ -]CHANGE/i', $body) === 1) {
+    if (
+        preg_match('/BREAKING[ -]CHANGES?/i', $title) === 1
+        || preg_match('/BREAKING[ -]CHANGES?/i', $body) === 1
+    ) {
         return 'major';
     }
 
@@ -108,6 +111,27 @@ function incrementVersion(string $version, string $bump): string
     }
 
     return sprintf('%d.%d.%d', $major, $minor, $patch);
+}
+
+function readComposerVersion(string $path): string
+{
+    $raw = file_get_contents($path);
+    if ($raw === false) {
+        throw new ReleaseScriptException('Could not read composer.json');
+    }
+
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        throw new ReleaseScriptException('Invalid composer.json');
+    }
+
+    $version = (string) ($decoded['version'] ?? '');
+    $version = ltrim(trim($version), 'v');
+    if (preg_match('/^\d+\.\d+\.\d+$/', $version) !== 1) {
+        throw new ReleaseScriptException('Could not parse semantic version from composer.json');
+    }
+
+    return $version;
 }
 
 function updateComposerVersion(string $path, string $version): void
@@ -185,6 +209,33 @@ function resolveBody(array $argv): string
 $title = getArgValue($argv, 'title');
 $body = resolveBody($argv);
 $outputPath = getArgValue($argv, 'output');
+$manualBump = strtolower(trim(getArgValue($argv, 'manual-bump')));
+$useCurrentVersion = strtolower(trim(getArgValue($argv, 'use-current-version', 'false'))) === 'true';
+
+if ($manualBump !== '') {
+    $allowed = ['major', 'minor', 'patch'];
+    if (!in_array($manualBump, $allowed, true)) {
+        throw new ReleaseScriptException('manual-bump must be one of: major, minor, patch');
+    }
+
+    $previousVersion = findLatestSemverTag();
+    if ($useCurrentVersion) {
+        $nextVersion = readComposerVersion('composer.json');
+    } else {
+        $nextVersion = incrementVersion($previousVersion, $manualBump);
+        updateComposerVersion('composer.json', $nextVersion);
+        updateConstantVersion('src/Constant.php', $nextVersion);
+    }
+
+    writeOutputs($outputPath, [
+        'should_release' => 'true',
+        'bump' => $manualBump,
+        'previous_version' => $previousVersion,
+        'version' => $nextVersion,
+        'tag' => 'v' . $nextVersion,
+    ]);
+    exit(0);
+}
 
 $bump = determineBumpType($title, $body);
 if ($bump === 'none') {


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` support to the release workflow with `version_bump`, `use_current_version`, and `prerelease` inputs
- keep merged-PR auto release flow intact while unifying metadata handling for both trigger paths
- fix release bump parsing to detect `BREAKING CHANGES` (including plural) in PR title/body and support manual bump arguments in `bump_version.php`

## Test plan
- [x] `php -l scripts/release/bump_version.php`
- [ ] Run workflow manually in GitHub Actions using `patch` bump
- [ ] Run workflow manually with `use_current_version=true`
- [ ] Merge a PR with `BREAKING CHANGE` marker and verify `major` bump

Made with [Cursor](https://cursor.com)