### PR TITLE
fix(release): queue concurrent releases serially instead of cancelling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ on:
 
 concurrency:
   group: release-${{ github.event.pull_request.base.ref || github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Changes the release-workflow concurrency from `cancel-in-progress: true` to `false`, so back-to-back release-eligible PR merges (or a workflow_dispatch landing on top of a running release) queue serially instead of aborting the earlier run.

## Why

With `cancel-in-progress: true`, two PRs merging within seconds can race:

- **Cancelled mid-test**: PR1's release aborts before any side effects. PR1's commits are on master but never published; PR2's release then publishes its own version that silently includes PR1's diffs under PR2's version label.
- **Cancelled mid-publish**: pyproject/composer + `src/Constant.php` have been bumped, the tag has been pushed, the Packagist update may have fired or partially fired. master/main is now ahead of Packagist with a half-finished release. PR2 then bumps from the orphan tag and publishes, creating divergence between git tags and Packagist history.

Release operations are not safe to interrupt. They need to run to completion. `cancel-in-progress: false` queues subsequent releases until the previous one finishes, which is what we want for a publish pipeline.

## Context

Reported originally by CodeRabbit on [stream-py PR #254](https://github.com/GetStream/stream-py/pull/254). The same pattern exists in `getstream-php`, `getstream-ruby`, and `getstream-net` — I copied the PHP concurrency block when drafting the stream-py rewrite, so all four share the bug. Sibling PRs going out to `getstream-ruby` and `getstream-net` with the same one-line fix.

Go/Java release.yml's recently proposed by Aditya (getstream-go #104, stream-sdk-java #59) currently have no concurrency block at all on `release.yml` — they're racy in a different way (auto and manual paths can collide on the same merged commit without any serialization). Flagging in those PRs separately.

## Test plan

Not directly verifiable from a single PR — the next time two PRs merge within the same workflow run window, the second should queue rather than cancel the first. Operational only; no test code change.
