### PR TITLE
feat: [CHA-2956] connection pooling: getstream-php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,17 +39,17 @@ Under PHP-FPM and CLI scripts, the PHP process exits at the end of each request 
 - Webhook handling spec helpers (CHA-2961): `UnknownEvent` class for forward-compat;
   `gunzipPayload`, `decodeSqsPayload`, `decodeSnsPayload` primitives;
   `verifyAndParseWebhook` HTTP composite; `parseSqs` / `parseSns`
-  queue composites (no signature — backend emits no HMAC for queue messages today;
+  queue composites (no signature: backend emits no HMAC for queue messages today;
   trust is established via AWS IAM controls on the SQS queue / SNS topic).
   Transparent gzip via magic-byte detection.
 - New `GetStream\Webhook` namespace alias (preferred); `GetStream\Generated\Webhook`
   retained as backward-compat alias. PSR-4 shim (`src/Webhook.php`) ensures the
   canonical name resolves on first touch.
-- New exception class: `GetStream\Exceptions\InvalidWebhookException` (unified —
-  covers signature mismatches, parse failures, decompression errors, etc.).
+- New exception class: `GetStream\Exceptions\InvalidWebhookException` (unified,
+  covering signature mismatches, parse failures, decompression errors, etc.).
 - New `GetStream\Models\UnknownEvent` class.
 - New instance methods on `GetStream\Client`: `verifySignature($body, $signature)`
-  and `verifyAndParseWebhook($body, $signature)` — drop the api_secret parameter
+  and `verifyAndParseWebhook($body, $signature)` that drop the api_secret parameter
   in favor of the client's stored secret. Dual API: static methods remain available.
 - New instance methods on `GetStream\Client`: `parseSqs(string $messageBody)`,
   `parseSns(string $notificationBody)` (no signature; AWS IAM).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,30 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Connection pool configuration on `ClientBuilder` ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)).
-  Four new chained methods, all `int` seconds:
+- Connection pool configuration on `ClientBuilder` ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)). Four new chained methods, all `int` seconds:
     * `maxConnsPerHost(int)` — default `5` (curl `CURLOPT_MAXCONNECTS`)
     * `idleTimeout(int)` — default `55` (no-op under PHP-FPM, see caveat below)
     * `connectTimeout(int)` — default `10` (Guzzle `connect_timeout`)
     * `requestTimeout(int)` — default `30` (Guzzle `timeout`)
 - `GetStream\Http\PoolConfig` immutable value object holding the 5 canonical knobs.
-- `HttpClientInterface::request()` gains an optional 5th `array $options = []` parameter
-  for per-call overrides (e.g., `['timeout' => 2]`). Backward-compatible.
-- INFO log on `ClientBuilder::build()` listing the effective pool config.
-  Emitted via `error_log()`; suppressed in PHPUnit runs.
+- `HttpClientInterface::request()` gains an optional 5th `array $options = []` parameter for per-call overrides (e.g., `['timeout' => 2]`). Backward-compatible.
+- INFO log on `ClientBuilder::build()` listing the effective pool config. Emitted via `error_log()`; suppressed in PHPUnit runs.
 - `GuzzleHttpClient::getPoolConfig()` accessor for diagnostics.
 
 ### Changed
 
-- `GuzzleHttpClient::__construct()` gains an optional 3rd `?PoolConfig $pool` parameter.
-  Existing callsites continue to work unchanged.
+- `GuzzleHttpClient::__construct()` gains an optional 3rd `?PoolConfig $pool` parameter. Existing callsites continue to work unchanged.
 
 ### PHP-FPM caveat
 
-Under PHP-FPM and CLI scripts, the PHP process exits at the end of each request and
-the curl handle dies with it. `idleTimeout` and `maxConnsPerHost` are accepted on the
-builder but have **no effect** on inter-request pooling in these runtimes. They take
-effect only in long-running PHP runtimes (Swoole, RoadRunner, ReactPHP, daemons).
+Under PHP-FPM and CLI scripts, the PHP process exits at the end of each request and the curl handle dies with it. `idleTimeout` and `maxConnsPerHost` are accepted on the builder but have **no effect** on inter-request pooling in these runtimes. They take effect only in long-running PHP runtimes (Swoole, RoadRunner, ReactPHP, daemons).
 
 ### Out of scope
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Connection pool configuration on `ClientBuilder` ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)). Four new chained methods, all `int` seconds:
-    * `maxConnsPerHost(int)`: default `5` (curl `CURLOPT_MAXCONNECTS`)
+    * `maxConnsPerHost(int)`: default `5` (advisory; sets curl `CURLOPT_MAXCONNECTS`, see caveat below)
     * `idleTimeout(int)`: default `55` (no-op under PHP-FPM, see caveat below)
     * `connectTimeout(int)`: default `10` (Guzzle `connect_timeout`)
     * `requestTimeout(int)`: default `30` (Guzzle `timeout`)
@@ -23,9 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `GuzzleHttpClient::__construct()` gains an optional 3rd `?PoolConfig $pool` parameter. Existing callsites continue to work unchanged.
 
-### PHP-FPM caveat
+### Pooling caveats
 
-Under PHP-FPM and CLI scripts, the PHP process exits at the end of each request and the curl handle dies with it. `idleTimeout` and `maxConnsPerHost` are accepted on the builder but have **no effect** on inter-request pooling in these runtimes. They take effect only in long-running PHP runtimes (Swoole, RoadRunner, ReactPHP, daemons).
+`idleTimeout` (PHP-FPM): under PHP-FPM and CLI scripts, the PHP process exits at the end of each request and the curl handle dies with it. `idleTimeout` is accepted on the builder but has **no effect** on inter-request pooling in these runtimes. It takes effect only in long-running PHP runtimes (Swoole, RoadRunner, ReactPHP, daemons).
+
+`maxConnsPerHost` (advisory, all runtimes): this sets curl `CURLOPT_MAXCONNECTS`, which only sizes a single curl handle's own connection cache. Under Guzzle's default `CurlHandler` it does **not** enforce a hard per-host concurrency cap, in any runtime. A real cap requires the consumer to supply a shared `GuzzleHttp\Handler\CurlMultiHandler` configured with `CURLMOPT_MAX_HOST_CONNECTIONS` (via `->httpClient(...)`); the SDK does not wire one by default.
 
 ### Out of scope
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Connection pool configuration on `ClientBuilder` ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)). Four new chained methods, all `int` seconds:
-    * `maxConnsPerHost(int)` — default `5` (curl `CURLOPT_MAXCONNECTS`)
-    * `idleTimeout(int)` — default `55` (no-op under PHP-FPM, see caveat below)
-    * `connectTimeout(int)` — default `10` (Guzzle `connect_timeout`)
-    * `requestTimeout(int)` — default `30` (Guzzle `timeout`)
+    * `maxConnsPerHost(int)` - default `5` (curl `CURLOPT_MAXCONNECTS`)
+    * `idleTimeout(int)` - default `55` (no-op under PHP-FPM, see caveat below)
+    * `connectTimeout(int)` - default `10` (Guzzle `connect_timeout`)
+    * `requestTimeout(int)` - default `30` (Guzzle `timeout`)
 - `GetStream\Http\PoolConfig` immutable value object holding the 5 canonical knobs.
 - `HttpClientInterface::request()` gains an optional 5th `array $options = []` parameter for per-call overrides (e.g., `['timeout' => 2]`). Backward-compatible.
 - INFO log on `ClientBuilder::build()` listing the effective pool config. Emitted via `error_log()`; suppressed in PHPUnit runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GetStream\Http\PoolConfig` immutable value object holding the 5 canonical knobs.
 - `HttpClientInterface::request()` gains an optional 5th `array $options = []` parameter
   for per-call overrides (e.g., `['timeout' => 2]`). Backward-compatible.
-- INFO log on `ClientBuilder::build()` listing the effective pool config (spec §8).
+- INFO log on `ClientBuilder::build()` listing the effective pool config.
   Emitted via `error_log()`; suppressed in PHPUnit runs.
 - `GuzzleHttpClient::getPoolConfig()` accessor for diagnostics.
 
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GuzzleHttpClient::__construct()` gains an optional 3rd `?PoolConfig $pool` parameter.
   Existing callsites continue to work unchanged.
 
-### PHP-FPM caveat (§9.1)
+### PHP-FPM caveat
 
 Under PHP-FPM and CLI scripts, the PHP process exits at the end of each request and
 the curl handle dies with it. `idleTimeout` and `maxConnsPerHost` are accepted on the
@@ -36,10 +36,8 @@ effect only in long-running PHP runtimes (Swoole, RoadRunner, ReactPHP, daemons)
 
 ### Out of scope
 
-- No env-var overrides (spec §3 defers this).
+- No env-var overrides.
 - No PSR-3 logger injection; INFO log goes through `error_log()`.
-
-[Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Connection-Pooling-Spec-3496a5d7f9f680749b8be9ee238ae108)
 
 ## [Unreleased]
 
@@ -67,8 +65,6 @@ effect only in long-running PHP runtimes (Swoole, RoadRunner, ReactPHP, daemons)
 ### Changed
 
 - No breaking changes.
-
-[Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Webhook-Handling-Spec-34b6a5d7f9f681e78003c443f227493c)
 
 ## [4.0.0] - 2026-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Connection pool configuration on `ClientBuilder` ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)). Four new chained methods, all `int` seconds:
-    * `maxConnsPerHost(int)`: default `5` (advisory; sets curl `CURLOPT_MAXCONNECTS`, see caveat below)
-    * `idleTimeout(int)`: default `55` (no-op under PHP-FPM, see caveat below)
+    * `maxConnsPerHost(int)`: default `5` (per-host concurrency cap via curl `CURLMOPT_MAX_HOST_CONNECTIONS` on a persistent multi handle; effective in long-running PHP runtimes)
+    * `idleTimeout(int)`: default `55` (per-connection lifetime cap via `CURLOPT_MAXLIFETIME_CONN`; effective in long-running PHP runtimes; requires libcurl 7.80.0 or later)
     * `connectTimeout(int)`: default `10` (Guzzle `connect_timeout`)
     * `requestTimeout(int)`: default `30` (Guzzle `timeout`)
 - `GetStream\Http\PoolConfig` immutable value object holding the 5 canonical knobs.
@@ -25,9 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Pooling caveats
 
-`idleTimeout` (PHP-FPM): under PHP-FPM and CLI scripts, the PHP process exits at the end of each request and the curl handle dies with it. `idleTimeout` is accepted on the builder but has **no effect** on inter-request pooling in these runtimes. It takes effect only in long-running PHP runtimes (Swoole, RoadRunner, ReactPHP, daemons).
+`maxConnsPerHost` and `idleTimeout` are enforced via libcurl's multi-handle pool (`CURLMOPT_MAX_HOST_CONNECTIONS`) and connection lifetime cap (`CURLOPT_MAXLIFETIME_CONN`). They take effect only when the SDK client is reused across requests within a single PHP process: long-running runtimes such as Swoole, RoadRunner, ReactPHP, and CLI daemons. Instantiate the SDK client once and reuse it.
 
-`maxConnsPerHost` (advisory, all runtimes): this sets curl `CURLOPT_MAXCONNECTS`, which only sizes a single curl handle's own connection cache. Under Guzzle's default `CurlHandler` it does **not** enforce a hard per-host concurrency cap, in any runtime. A real cap requires the consumer to supply a shared `GuzzleHttp\Handler\CurlMultiHandler` configured with `CURLMOPT_MAX_HOST_CONNECTIONS` (via `->httpClient(...)`); the SDK does not wire one by default.
+Under PHP-FPM (and one-shot CLI scripts) the PHP process exits at the end of each request, taking the multi handle and any pooled connections with it. The per-call request and connect timeouts still apply; pool sizing and idle cycling have no cross-request effect because there is nothing to keep alive between requests.
+
+`CURLOPT_MAXLIFETIME_CONN` requires libcurl 7.80.0 (Nov 2021) or later. If your PHP build links against an older libcurl, pooling still works without active lifetime cycling.
 
 ### Out of scope
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.0] - 2026-MM-DD
+
+### Added
+
+- Connection pool configuration on `ClientBuilder` ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)).
+  Four new chained methods, all `int` seconds:
+    * `maxConnsPerHost(int)` — default `5` (curl `CURLOPT_MAXCONNECTS`)
+    * `idleTimeout(int)` — default `55` (no-op under PHP-FPM, see caveat below)
+    * `connectTimeout(int)` — default `10` (Guzzle `connect_timeout`)
+    * `requestTimeout(int)` — default `30` (Guzzle `timeout`)
+- `GetStream\Http\PoolConfig` immutable value object holding the 5 canonical knobs.
+- `HttpClientInterface::request()` gains an optional 5th `array $options = []` parameter
+  for per-call overrides (e.g., `['timeout' => 2]`). Backward-compatible.
+- INFO log on `ClientBuilder::build()` listing the effective pool config (spec §8).
+  Emitted via `error_log()`; suppressed in PHPUnit runs.
+- `GuzzleHttpClient::getPoolConfig()` accessor for diagnostics.
+
+### Changed
+
+- `GuzzleHttpClient::__construct()` gains an optional 3rd `?PoolConfig $pool` parameter.
+  Existing callsites continue to work unchanged.
+
+### PHP-FPM caveat (§9.1)
+
+Under PHP-FPM and CLI scripts, the PHP process exits at the end of each request and
+the curl handle dies with it. `idleTimeout` and `maxConnsPerHost` are accepted on the
+builder but have **no effect** on inter-request pooling in these runtimes. They take
+effect only in long-running PHP runtimes (Swoole, RoadRunner, ReactPHP, daemons).
+
+### Out of scope
+
+- No env-var overrides (spec §3 defers this).
+- No PSR-3 logger injection; INFO log goes through `error_log()`.
+
+[Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Connection-Pooling-Spec-3496a5d7f9f680749b8be9ee238ae108)
+
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Connection pool configuration on `ClientBuilder` ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)). Four new chained methods, all `int` seconds:
-    * `maxConnsPerHost(int)` - default `5` (curl `CURLOPT_MAXCONNECTS`)
-    * `idleTimeout(int)` - default `55` (no-op under PHP-FPM, see caveat below)
-    * `connectTimeout(int)` - default `10` (Guzzle `connect_timeout`)
-    * `requestTimeout(int)` - default `30` (Guzzle `timeout`)
+    * `maxConnsPerHost(int)`: default `5` (curl `CURLOPT_MAXCONNECTS`)
+    * `idleTimeout(int)`: default `55` (no-op under PHP-FPM, see caveat below)
+    * `connectTimeout(int)`: default `10` (Guzzle `connect_timeout`)
+    * `requestTimeout(int)`: default `30` (Guzzle `timeout`)
 - `GetStream\Http\PoolConfig` immutable value object holding the 5 canonical knobs.
 - `HttpClientInterface::request()` gains an optional 5th `array $options = []` parameter for per-call overrides (e.g., `['timeout' => 2]`). Backward-compatible.
 - INFO log on `ClientBuilder::build()` listing the effective pool config. Emitted via `error_log()`; suppressed in PHPUnit runs.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $response = $client->getHttpClient()->request(
 
 **PHP-FPM caveat:** Under PHP-FPM and CLI scripts the curl handle dies with the request, so `idleTimeout` and `maxConnsPerHost` have no inter-request effect. They take effect in long-running runtimes (Swoole, RoadRunner, ReactPHP, daemons).
 
-**Escape hatch:** Passing your own client via `->httpClient($mine)` skips all 4 knobs — your client is used as-is.
+**Escape hatch:** Passing your own client via `->httpClient($mine)` skips all 4 knobs; your client is used as-is.
 
 ## Code Generation
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ STREAM_BASE_URL=https://chat.stream-io-api.com
 $client = (new GetStream\ClientBuilder())
     ->apiKey($apiKey)
     ->apiSecret($apiSecret)
-    ->maxConnsPerHost(5)   // default 5 (advisory, see below)
-    ->idleTimeout(55)      // default 55s (no-op under PHP-FPM, see below)
+    ->maxConnsPerHost(5)   // default 5 (per-host concurrency cap, see runtime caveats)
+    ->idleTimeout(55)      // default 55s (per-connection lifetime cap, see runtime caveats)
     ->connectTimeout(10)   // default 10s
     ->requestTimeout(30)   // default 30s
     ->build();
@@ -53,9 +53,7 @@ $response = $client->getHttpClient()->request(
 
 Per-call `curl` overrides replace (do not merge with) the client-level `curl` options, since Guzzle unions options shallowly. Only `['timeout' => N]` is documented for per-call use.
 
-**`idleTimeout` (PHP-FPM caveat):** under PHP-FPM and CLI scripts the curl handle dies with the request, so `idleTimeout` has no inter-request effect. It takes effect in long-running runtimes (Swoole, RoadRunner, ReactPHP, daemons).
-
-**`maxConnsPerHost` (advisory):** this sets curl `CURLOPT_MAXCONNECTS`, which only sizes a single curl handle's own connection cache. Under Guzzle's default `CurlHandler` it does not enforce a hard per-host concurrency cap, in any runtime. For a real cap, supply your own client via `->httpClient(...)` backed by a shared `GuzzleHttp\Handler\CurlMultiHandler` configured with `CURLMOPT_MAX_HOST_CONNECTIONS`.
+**Runtime caveats.** `maxConnsPerHost` and `idleTimeout` are enforced via libcurl's persistent multi-handle pool (`CURLMOPT_MAX_HOST_CONNECTIONS` and `CURLOPT_MAXLIFETIME_CONN`). They take effect only when the SDK client is reused across requests within a single PHP process: long-running runtimes such as Swoole, RoadRunner, ReactPHP, and CLI daemons. Instantiate the SDK client once and reuse it. Under PHP-FPM (and one-shot CLI scripts) the PHP process exits at the end of each request, so there is no cross-request pool to size; the per-call request and connect timeouts still apply. `idleTimeout` requires libcurl 7.80.0 (Nov 2021) or later; pooling still works without it on older builds, just without active lifetime cycling.
 
 **Escape hatch:** Passing your own client via `->httpClient($mine)` skips all 4 knobs; your client is used as-is.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,31 @@ STREAM_API_SECRET=your_api_secret_here
 STREAM_BASE_URL=https://chat.stream-io-api.com
 ```
 
+## Connection Pool Tuning
+
+```php
+$client = (new GetStream\ClientBuilder())
+    ->apiKey($apiKey)
+    ->apiSecret($apiSecret)
+    ->maxConnsPerHost(5)   // default 5
+    ->idleTimeout(55)      // default 55s (no-op under PHP-FPM, see below)
+    ->connectTimeout(10)   // default 10s
+    ->requestTimeout(30)   // default 30s
+    ->build();
+```
+
+**Per-call timeout override:**
+
+```php
+$response = $client->getHttpClient()->request(
+    'GET', $url, $headers, null, ['timeout' => 2]
+);
+```
+
+**PHP-FPM caveat:** Under PHP-FPM and CLI scripts the curl handle dies with the request, so `idleTimeout` and `maxConnsPerHost` have no inter-request effect. They take effect in long-running runtimes (Swoole, RoadRunner, ReactPHP, daemons).
+
+**Escape hatch:** Passing your own client via `->httpClient($mine)` skips all 4 knobs — your client is used as-is.
+
 ## Code Generation
 
 Generate API methods from OpenAPI spec:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ STREAM_BASE_URL=https://chat.stream-io-api.com
 $client = (new GetStream\ClientBuilder())
     ->apiKey($apiKey)
     ->apiSecret($apiSecret)
-    ->maxConnsPerHost(5)   // default 5
+    ->maxConnsPerHost(5)   // default 5 (advisory, see below)
     ->idleTimeout(55)      // default 55s (no-op under PHP-FPM, see below)
     ->connectTimeout(10)   // default 10s
     ->requestTimeout(30)   // default 30s
@@ -51,7 +51,11 @@ $response = $client->getHttpClient()->request(
 );
 ```
 
-**PHP-FPM caveat:** Under PHP-FPM and CLI scripts the curl handle dies with the request, so `idleTimeout` and `maxConnsPerHost` have no inter-request effect. They take effect in long-running runtimes (Swoole, RoadRunner, ReactPHP, daemons).
+Per-call `curl` overrides replace (do not merge with) the client-level `curl` options, since Guzzle unions options shallowly. Only `['timeout' => N]` is documented for per-call use.
+
+**`idleTimeout` (PHP-FPM caveat):** under PHP-FPM and CLI scripts the curl handle dies with the request, so `idleTimeout` has no inter-request effect. It takes effect in long-running runtimes (Swoole, RoadRunner, ReactPHP, daemons).
+
+**`maxConnsPerHost` (advisory):** this sets curl `CURLOPT_MAXCONNECTS`, which only sizes a single curl handle's own connection cache. Under Guzzle's default `CurlHandler` it does not enforce a hard per-host concurrency cap, in any runtime. For a real cap, supply your own client via `->httpClient(...)` backed by a shared `GuzzleHttp\Handler\CurlMultiHandler` configured with `CURLMOPT_MAX_HOST_CONNECTIONS`.
 
 **Escape hatch:** Passing your own client via `->httpClient($mine)` skips all 4 knobs; your client is used as-is.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "getstream/getstream-php",
     "description": "PHP SDK for GetStream API",
-    "version": "v7.2.0",
+    "version": "v7.3.0",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,5 +17,8 @@
             <directory suffix=".php">src</directory>
         </include>
     </source>
+    <php>
+        <const name="PHPUNIT_RUNNING" value="true"/>
+    </php>
 </phpunit>
 

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -259,9 +259,9 @@ class ClientBuilder
     }
 
     /**
-     * Resolve the HttpClient. If the user supplied one via httpClient(),
-     * return it as-is (escape hatch). Otherwise build a GuzzleHttpClient
-     * with the configured PoolConfig and emit the INFO log.
+     * Resolve the HttpClient.
+     * If the user supplied one via httpClient(), return it as-is (escape hatch).
+     * Otherwise build a GuzzleHttpClient with the configured PoolConfig and emit the INFO log.
      */
     private function resolveHttpClient(): HttpClientInterface
     {
@@ -288,8 +288,8 @@ class ClientBuilder
     }
 
     /**
-     * Emit one INFO log line via error_log(). Suppressed under PHPUnit to
-     * keep test output clean (PHPUNIT_RUNNING constant is set in phpunit.xml).
+     * Emit one INFO log line via error_log().
+     * Suppressed under PHPUnit to keep test output clean (PHPUNIT_RUNNING constant is set in phpunit.xml).
      */
     private function logInfo(string $message): void
     {

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -260,8 +260,8 @@ class ClientBuilder
 
     /**
      * Resolve the HttpClient. If the user supplied one via httpClient(),
-     * return it as-is (§7 escape hatch). Otherwise build a GuzzleHttpClient
-     * with the configured PoolConfig and emit the §8 INFO log.
+     * return it as-is (escape hatch). Otherwise build a GuzzleHttpClient
+     * with the configured PoolConfig and emit the INFO log.
      */
     private function resolveHttpClient(): HttpClientInterface
     {

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -261,14 +261,40 @@ class ClientBuilder
     /**
      * Resolve the HttpClient. If the user supplied one via httpClient(),
      * return it as-is (§7 escape hatch). Otherwise build a GuzzleHttpClient
-     * with the configured PoolConfig.
+     * with the configured PoolConfig and emit the §8 INFO log.
      */
     private function resolveHttpClient(): HttpClientInterface
     {
         if ($this->httpClient !== null) {
+            $this->logInfo(
+                'getstream-php connection pool: user_http_client=true (5 knobs not applied)'
+            );
+
             return $this->httpClient;
         }
 
-        return new GuzzleHttpClient([], 3, $this->pool);
+        $client = new GuzzleHttpClient([], 3, $this->pool);
+
+        $this->logInfo(sprintf(
+            'getstream-php connection pool: max_conns_per_host=%d idle_timeout=%ds connect_timeout=%ds request_timeout=%ds user_http_client=false',
+            $this->pool->maxConnsPerHost,
+            $this->pool->idleTimeout,
+            $this->pool->connectTimeout,
+            $this->pool->requestTimeout,
+        ));
+
+        return $client;
+    }
+
+    /**
+     * Emit one INFO log line via error_log(). Suppressed under PHPUnit to
+     * keep test output clean (PHPUNIT_RUNNING constant is set in phpunit.xml).
+     */
+    private function logInfo(string $message): void
+    {
+        if (defined('PHPUNIT_RUNNING') && PHPUNIT_RUNNING) {
+            return;
+        }
+        error_log('[INFO] ' . $message);
     }
 }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -260,9 +260,8 @@ class ClientBuilder
 
     /**
      * Resolve the HttpClient. If the user supplied one via httpClient(),
-     * return it as-is (§7 escape hatch). Otherwise build a GuzzleHttpClient.
-     * Task 3 will pass $this->pool here once GuzzleHttpClient's constructor
-     * accepts a PoolConfig argument.
+     * return it as-is (§7 escape hatch). Otherwise build a GuzzleHttpClient
+     * with the configured PoolConfig.
      */
     private function resolveHttpClient(): HttpClientInterface
     {
@@ -270,6 +269,6 @@ class ClientBuilder
             return $this->httpClient;
         }
 
-        return new GuzzleHttpClient();
+        return new GuzzleHttpClient([], 3, $this->pool);
     }
 }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -6,7 +6,9 @@ namespace GetStream;
 
 use Dotenv\Dotenv;
 use GetStream\Exceptions\StreamException;
+use GetStream\Http\GuzzleHttpClient;
 use GetStream\Http\HttpClientInterface;
+use GetStream\Http\PoolConfig;
 
 /**
  * Builder class for creating GetStream clients with environment variable support.
@@ -19,6 +21,12 @@ class ClientBuilder
     private ?HttpClientInterface $httpClient = null;
     private bool $loadEnv = true;
     private ?string $envPath = null;
+    private PoolConfig $pool;
+
+    public function __construct()
+    {
+        $this->pool = new PoolConfig();
+    }
 
     /**
      * Set the API key.
@@ -56,6 +64,46 @@ class ClientBuilder
     public function httpClient(HttpClientInterface $httpClient): self
     {
         $this->httpClient = $httpClient;
+
+        return $this;
+    }
+
+    /** Cap concurrent TCP connections per host. Default: 5. Ignored when httpClient() is used. */
+    public function maxConnsPerHost(int $n): self
+    {
+        $this->pool = $this->pool->withMaxConnsPerHost($n);
+
+        return $this;
+    }
+
+    /**
+     * Idle connection lifetime in seconds. Default: 55.
+     * No-op under PHP-FPM (curl handle dies with the request); honored in long-running runtimes.
+     * Ignored when httpClient() is used.
+     */
+    public function idleTimeout(int $seconds): self
+    {
+        $this->pool = $this->pool->withIdleTimeout($seconds);
+
+        return $this;
+    }
+
+    /** TCP + TLS handshake cap in seconds (Guzzle `connect_timeout`). Default: 10. Ignored when httpClient() is used. */
+    public function connectTimeout(int $seconds): self
+    {
+        $this->pool = $this->pool->withConnectTimeout($seconds);
+
+        return $this;
+    }
+
+    /**
+     * Default per-request timeout in seconds (Guzzle `timeout`). Default: 30.
+     * Per-call override: pass `['timeout' => N]` as the 5th arg of HttpClientInterface::request().
+     * Ignored when httpClient() is used.
+     */
+    public function requestTimeout(int $seconds): self
+    {
+        $this->pool = $this->pool->withRequestTimeout($seconds);
 
         return $this;
     }
@@ -102,7 +150,7 @@ class ClientBuilder
     {
         $this->loadCreds();
 
-        return new Client($this->apiKey, $this->apiSecret, $this->baseUrl, $this->httpClient);
+        return new Client($this->apiKey, $this->apiSecret, $this->baseUrl, $this->resolveHttpClient());
     }
 
     /**
@@ -112,7 +160,7 @@ class ClientBuilder
     {
         $this->loadCreds();
 
-        return new FeedsV3Client($this->apiKey, $this->apiSecret, $this->baseUrl, $this->httpClient);
+        return new FeedsV3Client($this->apiKey, $this->apiSecret, $this->baseUrl, $this->resolveHttpClient());
     }
 
     /**
@@ -122,7 +170,7 @@ class ClientBuilder
     {
         $this->loadCreds();
 
-        return new ChatClient($this->apiKey, $this->apiSecret, $this->baseUrl, $this->httpClient);
+        return new ChatClient($this->apiKey, $this->apiSecret, $this->baseUrl, $this->resolveHttpClient());
     }
 
     /**
@@ -132,7 +180,7 @@ class ClientBuilder
     {
         $this->loadCreds();
 
-        return new VideoClient($this->apiKey, $this->apiSecret, $this->baseUrl, $this->httpClient);
+        return new VideoClient($this->apiKey, $this->apiSecret, $this->baseUrl, $this->resolveHttpClient());
     }
 
     /**
@@ -142,7 +190,7 @@ class ClientBuilder
     {
         $this->loadCreds();
 
-        return new ModerationClient($this->apiKey, $this->apiSecret, $this->baseUrl, $this->httpClient);
+        return new ModerationClient($this->apiKey, $this->apiSecret, $this->baseUrl, $this->resolveHttpClient());
     }
 
     public function loadCreds(): void
@@ -208,5 +256,20 @@ class ClientBuilder
         $value = $_ENV[$name] ?? $_SERVER[$name] ?? getenv($name);
 
         return $value !== false ? $value : null;
+    }
+
+    /**
+     * Resolve the HttpClient. If the user supplied one via httpClient(),
+     * return it as-is (§7 escape hatch). Otherwise build a GuzzleHttpClient.
+     * Task 3 will pass $this->pool here once GuzzleHttpClient's constructor
+     * accepts a PoolConfig argument.
+     */
+    private function resolveHttpClient(): HttpClientInterface
+    {
+        if ($this->httpClient !== null) {
+            return $this->httpClient;
+        }
+
+        return new GuzzleHttpClient();
     }
 }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -265,12 +265,13 @@ class ClientBuilder
      */
     private function resolveHttpClient(): HttpClientInterface
     {
-        if ($this->httpClient !== null) {
+        $user = $this->httpClient;
+        if ($user !== null) {
             $this->logInfo(
                 'getstream-php connection pool: user_http_client=true (5 knobs not applied)'
             );
 
-            return $this->httpClient;
+            return $user;
         }
 
         $client = new GuzzleHttpClient([], 3, $this->pool);

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -68,7 +68,11 @@ class ClientBuilder
         return $this;
     }
 
-    /** Cap concurrent TCP connections per host. Default: 5. Ignored when httpClient() is used. */
+    /**
+     * Advisory hint for per-host connections. Default: 5. Ignored when httpClient() is used.
+     * Sets curl CURLOPT_MAXCONNECTS (a single curl handle's connection-cache size); under Guzzle's
+     * default CurlHandler this does not enforce a hard per-host concurrency cap in any runtime.
+     */
     public function maxConnsPerHost(int $n): self
     {
         $this->pool = $this->pool->withMaxConnsPerHost($n);

--- a/src/Constant.php
+++ b/src/Constant.php
@@ -6,5 +6,5 @@ namespace GetStream;
 
 class Constant
 {
-    public const VERSION = '7.2.0';
+    public const VERSION = '7.3.0';
 }

--- a/src/Generated/Webhook.php
+++ b/src/Generated/Webhook.php
@@ -639,7 +639,7 @@ class Webhook
      * magic-byte detection decides whether to decompress.
      *
      * {@see self::parseSqs()} sits on top of this and works transparently for
-     * both wire formats — no caller code change, no flag, no header.
+     * both wire formats: no caller code change, no flag, no header.
      *
      * @throws InvalidWebhookException if gzip decompression fails (only when input has gzip magic prefix)
      */
@@ -647,7 +647,7 @@ class Webhook
     {
         $decoded = \base64_decode($messageBody, true);
         if ($decoded === false) {
-            // Not base64 — treat input as raw bytes (uncompressed wire format).
+            // Not base64, so treat input as raw bytes (uncompressed wire format).
             $decoded = $messageBody;
         }
         return self::gunzipPayload($decoded);
@@ -659,7 +659,7 @@ class Webhook
      * string flows through.
      *
      * Heuristic: try to JSON-parse the input. If it yields an array with a
-     * string 'Message' field, that's the envelope shape — return the Message.
+     * string 'Message' field, that's the envelope shape; return the Message.
      * Otherwise the input is presumed to BE the pre-extracted Message
      * (base64-encoded bytes are not valid JSON, so this falls through cleanly).
      */

--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -11,6 +11,8 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\HandlerStack;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -37,25 +39,45 @@ class GuzzleHttpClient implements HttpClientInterface
     {
         $pool = $pool ?? new PoolConfig();
 
+        // Persistent multi handle: routes every request (sync and async) through one
+        // libcurl multi handle that holds a connection pool for the lifetime of this
+        // GuzzleHttpClient instance. CURLMOPT_MAX_HOST_CONNECTIONS is a real per-host
+        // concurrency cap inside the multi handle; CURLMOPT_MAXCONNECTS sizes the
+        // multi handle's overall connection cache. Pooling takes effect only when this
+        // instance is reused across requests (long-running runtimes: Swoole, RoadRunner,
+        // ReactPHP, CLI daemons). Under PHP-FPM the PHP process exits per request and
+        // the multi handle dies with it; the per-call request/connect timeouts still
+        // apply but there is no cross-request connection reuse.
+        $multi = new CurlMultiHandler([
+            'options' => [
+                CURLMOPT_MAX_HOST_CONNECTIONS => $pool->maxConnsPerHost,
+                CURLMOPT_MAXCONNECTS => $pool->maxConnsPerHost,
+            ],
+        ]);
+        $defaultHandler = HandlerStack::create($multi);
+
+        $curlOptions = [
+            CURLOPT_FORBID_REUSE => 0, // KeepAlive invariant: allow connection reuse.
+        ];
+        // CURLOPT_MAXLIFETIME_CONN (libcurl >= 7.80.0) caps how long a pooled connection
+        // can be reused since it was created. We use it to recycle connections ahead of
+        // the upstream load balancer's idle close window. If the constant is not present
+        // on this PHP build, pooling still works without active lifetime capping.
+        if (defined('CURLOPT_MAXLIFETIME_CONN')) {
+            $curlOptions[\constant('CURLOPT_MAXLIFETIME_CONN')] = $pool->idleTimeout;
+        }
+
         $defaultConfig = [
             'timeout' => $pool->requestTimeout,
             'connect_timeout' => $pool->connectTimeout,
-            'http_errors' => false, // We'll handle errors ourselves
-            'curl' => [
-                // Advisory only: CURLOPT_MAXCONNECTS sizes this single curl handle's own
-                // connection cache. Under Guzzle's default CurlHandler it does NOT enforce a
-                // hard per-host concurrency cap (in any runtime); a real cap needs a shared
-                // CurlMultiHandler with CURLMOPT_MAX_HOST_CONNECTIONS, which we do not wire.
-                // idleTimeout has no direct Guzzle/curl analogue; honored only in long-running
-                // runtimes. Under PHP-FPM idle sockets die with the request.
-                // See the pooling caveats in the README/CHANGELOG.
-                CURLOPT_MAXCONNECTS => $pool->maxConnsPerHost,
-                CURLOPT_FORBID_REUSE => 0, // explicit: allow connection reuse (KeepAlive invariant)
-            ],
+            'http_errors' => false, // We handle errors ourselves.
+            'handler' => $defaultHandler,
+            'curl' => $curlOptions,
         ];
 
-        // User-supplied $config wins.
-        // array_replace_recursive preserves the user's curl array while filling in defaults we set above.
+        // User-supplied $config wins. array_replace_recursive lets callers override the
+        // handler (used by tests with MockHandler) or extend the curl options without
+        // wiping our defaults.
         $merged = array_replace_recursive($defaultConfig, $config);
 
         $this->client = new GuzzleClient($merged);

--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -43,16 +43,16 @@ class GuzzleHttpClient implements HttpClientInterface
             'http_errors' => false, // We'll handle errors ourselves
             'curl' => [
                 // Cap concurrent connections opened by curl's internal multi handle.
-                // IdleTimeout has no direct Guzzle/curl analogue; honored only in
-                // long-running runtimes. For PHP-FPM, idle sockets die with the
-                // request. See the PHP-FPM note in the README/CHANGELOG.
+                // IdleTimeout has no direct Guzzle/curl analogue; honored only in long-running runtimes.
+                // For PHP-FPM, idle sockets die with the request.
+                // See the PHP-FPM note in the README/CHANGELOG.
                 CURLOPT_MAXCONNECTS => $pool->maxConnsPerHost,
                 CURLOPT_FORBID_REUSE => 0, // explicit: allow connection reuse (KeepAlive invariant)
             ],
         ];
 
-        // User-supplied $config wins. array_replace_recursive preserves the
-        // user's curl array while filling in defaults we set above.
+        // User-supplied $config wins.
+        // array_replace_recursive preserves the user's curl array while filling in defaults we set above.
         $merged = array_replace_recursive($defaultConfig, $config);
 
         $this->client = new GuzzleClient($merged);
@@ -91,8 +91,8 @@ class GuzzleHttpClient implements HttpClientInterface
                 'headers' => $headers,
             ];
 
-            // Per-call overrides. 'timeout' is the canonical key; any
-            // other valid Guzzle key is also forwarded.
+            // Per-call overrides.
+            // 'timeout' is the canonical key; any other valid Guzzle key is also forwarded.
             foreach ($options as $key => $value) {
                 $requestOptions[$key] = $value;
             }

--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -73,34 +73,46 @@ class GuzzleHttpClient implements HttpClientInterface
      * @param string $url     Full URL to request
      * @param array  $headers Request headers
      * @param mixed  $body    Request body
+     * @param array  $options Per-call Guzzle option overrides (e.g. ['timeout' => 2])
      *
      * @return StreamResponse<mixed>
      *
      * @throws StreamException
      */
-    public function request(string $method, string $url, array $headers = [], mixed $body = null): StreamResponse
-    {
+    public function request(
+        string $method,
+        string $url,
+        array $headers = [],
+        mixed $body = null,
+        array $options = []
+    ): StreamResponse {
         try {
-            $options = [
+            $requestOptions = [
                 'headers' => $headers,
             ];
+
+            // Per-call overrides (§5.2). 'timeout' is the canonical key; any
+            // other valid Guzzle key is also forwarded.
+            foreach ($options as $key => $value) {
+                $requestOptions[$key] = $value;
+            }
 
             // Add body if provided
             if ($body !== null) {
                 // Check if this is multipart form data (array of arrays with 'name' and 'contents')
                 if (is_array($body) && !empty($body) && isset($body[0]) && is_array($body[0]) && isset($body[0]['name'])) {
                     // This is multipart form data
-                    $options['multipart'] = $body;
+                    $requestOptions['multipart'] = $body;
                 } elseif (is_array($body) || is_object($body)) {
-                    $options['json'] = $body;
+                    $requestOptions['json'] = $body;
                 } else {
-                    $options['body'] = $body;
+                    $requestOptions['body'] = $body;
                 }
             }
 
             // Retry loop for rate-limited responses
             for ($attempt = 0;; $attempt++) {
-                $response = $this->client->request($method, $url, $options);
+                $response = $this->client->request($method, $url, $requestOptions);
 
                 if ($response->getStatusCode() !== 429 || $attempt >= $this->maxRetries) {
                     return $this->createStreamResponse($response);

--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -23,22 +23,47 @@ class GuzzleHttpClient implements HttpClientInterface
     /** Maximum number of retries for rate-limited (429) responses. */
     private int $maxRetries;
 
+    /** @var PoolConfig Effective pool configuration (kept for diagnostics). */
+    private PoolConfig $pool;
+
     /**
      * Create a new GuzzleHttpClient.
      *
-     * @param array $config     Guzzle client configuration
-     * @param int   $maxRetries Maximum retries for 429 rate-limit responses (default 3)
+     * @param array            $config     Guzzle client configuration (wins over $pool defaults)
+     * @param int              $maxRetries Maximum retries for 429 rate-limit responses (default 3)
+     * @param PoolConfig|null  $pool       Connection pool configuration. When null, spec defaults apply.
      */
-    public function __construct(array $config = [], int $maxRetries = 3)
+    public function __construct(array $config = [], int $maxRetries = 3, ?PoolConfig $pool = null)
     {
+        $pool = $pool ?? new PoolConfig();
+
         $defaultConfig = [
-            'timeout' => 30,
-            'connect_timeout' => 10,
+            'timeout' => $pool->requestTimeout,
+            'connect_timeout' => $pool->connectTimeout,
             'http_errors' => false, // We'll handle errors ourselves
+            'curl' => [
+                // Cap concurrent connections opened by curl's internal multi handle.
+                // IdleTimeout has no direct Guzzle/curl analogue; honored only in
+                // long-running runtimes. For PHP-FPM, idle sockets die with the
+                // request — see CHANGELOG §9.1.
+                CURLOPT_MAXCONNECTS => $pool->maxConnsPerHost,
+                CURLOPT_FORBID_REUSE => 0, // explicit: allow connection reuse (KeepAlive invariant)
+            ],
         ];
 
-        $this->client = new GuzzleClient(array_merge($defaultConfig, $config));
+        // User-supplied $config wins. array_replace_recursive preserves the
+        // user's curl array while filling in defaults we set above.
+        $merged = array_replace_recursive($defaultConfig, $config);
+
+        $this->client = new GuzzleClient($merged);
         $this->maxRetries = $maxRetries;
+        $this->pool = $pool;
+    }
+
+    /** Return the effective PoolConfig (for diagnostics / logging). */
+    public function getPoolConfig(): PoolConfig
+    {
+        return $this->pool;
     }
 
     /**

--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -42,10 +42,13 @@ class GuzzleHttpClient implements HttpClientInterface
             'connect_timeout' => $pool->connectTimeout,
             'http_errors' => false, // We'll handle errors ourselves
             'curl' => [
-                // Cap concurrent connections opened by curl's internal multi handle.
-                // IdleTimeout has no direct Guzzle/curl analogue; honored only in long-running runtimes.
-                // For PHP-FPM, idle sockets die with the request.
-                // See the PHP-FPM note in the README/CHANGELOG.
+                // Advisory only: CURLOPT_MAXCONNECTS sizes this single curl handle's own
+                // connection cache. Under Guzzle's default CurlHandler it does NOT enforce a
+                // hard per-host concurrency cap (in any runtime); a real cap needs a shared
+                // CurlMultiHandler with CURLMOPT_MAX_HOST_CONNECTIONS, which we do not wire.
+                // idleTimeout has no direct Guzzle/curl analogue; honored only in long-running
+                // runtimes. Under PHP-FPM idle sockets die with the request.
+                // See the pooling caveats in the README/CHANGELOG.
                 CURLOPT_MAXCONNECTS => $pool->maxConnsPerHost,
                 CURLOPT_FORBID_REUSE => 0, // explicit: allow connection reuse (KeepAlive invariant)
             ],

--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -45,7 +45,7 @@ class GuzzleHttpClient implements HttpClientInterface
                 // Cap concurrent connections opened by curl's internal multi handle.
                 // IdleTimeout has no direct Guzzle/curl analogue; honored only in
                 // long-running runtimes. For PHP-FPM, idle sockets die with the
-                // request — see CHANGELOG §9.1.
+                // request. See the PHP-FPM note in the README/CHANGELOG.
                 CURLOPT_MAXCONNECTS => $pool->maxConnsPerHost,
                 CURLOPT_FORBID_REUSE => 0, // explicit: allow connection reuse (KeepAlive invariant)
             ],
@@ -91,7 +91,7 @@ class GuzzleHttpClient implements HttpClientInterface
                 'headers' => $headers,
             ];
 
-            // Per-call overrides (§5.2). 'timeout' is the canonical key; any
+            // Per-call overrides. 'timeout' is the canonical key; any
             // other valid Guzzle key is also forwarded.
             foreach ($options as $key => $value) {
                 $requestOptions[$key] = $value;

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -20,10 +20,8 @@ interface HttpClientInterface
      * @param array  $headers Request headers
      * @param mixed  $body    Request body (will be JSON encoded if array)
      * @param array  $options Per-call options. Supported keys:
-     *                       - 'timeout' (int|float seconds): overrides the client's
-     *                         RequestTimeout for this single call.
-     *                       Implementations MAY accept additional keys but MUST
-     *                       silently ignore unknown ones.
+     *                       - 'timeout' (int|float seconds): overrides the client's RequestTimeout for this single call.
+     *                       Implementations MAY accept additional keys but MUST silently ignore unknown ones.
      *
      * @return StreamResponse<mixed>
      *

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -19,10 +19,21 @@ interface HttpClientInterface
      * @param string $url     Full URL to request
      * @param array  $headers Request headers
      * @param mixed  $body    Request body (will be JSON encoded if array)
+     * @param array  $options Per-call options. Supported keys:
+     *                       - 'timeout' (int|float seconds): overrides the client's
+     *                         RequestTimeout for this single call (§5.2).
+     *                       Implementations MAY accept additional keys but MUST
+     *                       silently ignore unknown ones.
      *
      * @return StreamResponse<mixed>
      *
      * @throws StreamException
      */
-    public function request(string $method, string $url, array $headers = [], mixed $body = null): StreamResponse;
+    public function request(
+        string $method,
+        string $url,
+        array $headers = [],
+        mixed $body = null,
+        array $options = []
+    ): StreamResponse;
 }

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -21,7 +21,7 @@ interface HttpClientInterface
      * @param mixed  $body    Request body (will be JSON encoded if array)
      * @param array  $options Per-call options. Supported keys:
      *                       - 'timeout' (int|float seconds): overrides the client's
-     *                         RequestTimeout for this single call (§5.2).
+     *                         RequestTimeout for this single call.
      *                       Implementations MAY accept additional keys but MUST
      *                       silently ignore unknown ones.
      *

--- a/src/Http/PoolConfig.php
+++ b/src/Http/PoolConfig.php
@@ -6,8 +6,8 @@ namespace GetStream\Http;
 
 /**
  * Immutable value object for the 5 canonical HTTP connection-pool knobs.
- * Defaults: 5 conns/host, 55s idle, 10s connect, 30s request. KeepAlive is an
- * invariant (true). All durations are whole seconds.
+ * Defaults: 5 conns/host, 55s idle, 10s connect, 30s request.
+ * KeepAlive is an invariant (true). All durations are whole seconds.
  */
 final class PoolConfig
 {

--- a/src/Http/PoolConfig.php
+++ b/src/Http/PoolConfig.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GetStream\Http;
 
 /**
- * Immutable value object for the 5 canonical HTTP connection-pool knobs (spec §4).
+ * Immutable value object for the 5 canonical HTTP connection-pool knobs.
  * Defaults: 5 conns/host, 55s idle, 10s connect, 30s request. KeepAlive is an
  * invariant (true). All durations are whole seconds.
  */

--- a/src/Http/PoolConfig.php
+++ b/src/Http/PoolConfig.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetStream\Http;
+
+/**
+ * Immutable value object for the 5 canonical HTTP connection-pool knobs (spec §4).
+ * Defaults: 5 conns/host, 55s idle, 10s connect, 30s request. KeepAlive is an
+ * invariant (true). All durations are whole seconds.
+ */
+final class PoolConfig
+{
+    public function __construct(
+        public readonly int $maxConnsPerHost = 5,
+        public readonly int $idleTimeout = 55,
+        public readonly int $connectTimeout = 10,
+        public readonly int $requestTimeout = 30,
+    ) {
+    }
+
+    public function withMaxConnsPerHost(int $n): self
+    {
+        return new self($n, $this->idleTimeout, $this->connectTimeout, $this->requestTimeout);
+    }
+
+    public function withIdleTimeout(int $seconds): self
+    {
+        return new self($this->maxConnsPerHost, $seconds, $this->connectTimeout, $this->requestTimeout);
+    }
+
+    public function withConnectTimeout(int $seconds): self
+    {
+        return new self($this->maxConnsPerHost, $this->idleTimeout, $seconds, $this->requestTimeout);
+    }
+
+    public function withRequestTimeout(int $seconds): self
+    {
+        return new self($this->maxConnsPerHost, $this->idleTimeout, $this->connectTimeout, $seconds);
+    }
+}

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -269,10 +269,15 @@ class ClientBuilderTest extends TestCase
     public function userSuppliedHttpClientBypassesBuild(): void
     {
         $mock = $this->createMock(HttpClientInterface::class);
+
+        // The mock must NEVER have request() called during build() — building
+        // should be a pure construction step, no probe requests.
+        $mock->expects(self::never())->method('request');
+
         $client = (new ClientBuilder())
             ->apiKey('k')
             ->apiSecret('s')
-            ->maxConnsPerHost(99) // these 4 must NOT mutate $mock (§7)
+            ->maxConnsPerHost(99)
             ->idleTimeout(99)
             ->connectTimeout(99)
             ->requestTimeout(99)
@@ -280,6 +285,10 @@ class ClientBuilderTest extends TestCase
             ->skipEnvLoad()
             ->build();
 
+        // Identity check: the user's exact instance comes back unwrapped.
         self::assertSame($mock, $client->getHttpClient());
+
+        // And it is NOT a GuzzleHttpClient (no pool config is applied to it).
+        self::assertNotInstanceOf(\GetStream\Http\GuzzleHttpClient::class, $client->getHttpClient());
     }
 }

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -231,10 +231,50 @@ class ClientBuilderTest extends TestCase
             ->apiKey('test')
             ->apiSecret('test')
             ->baseUrl('test')
+            ->maxConnsPerHost(5)
+            ->idleTimeout(55)
+            ->connectTimeout(10)
+            ->requestTimeout(30)
             ->httpClient($this->mockHttpClient)
             ->skipEnvLoad()
             ->envPath('/test/path');
 
         self::assertSame($builder, $result);
+    }
+
+    /** @test */
+    public function poolConfigKnobsAreChained(): void
+    {
+        // After Task 3 wires GuzzleHttpClient::__construct(?PoolConfig), this
+        // test will assert against $client->getHttpClient()->getPoolConfig().
+        // For now, we just assert the builder exposes the 4 fluent methods
+        // and returns $this for chaining (Task 2 scope).
+        $builder = (new ClientBuilder())
+            ->apiKey('k')
+            ->apiSecret('s')
+            ->maxConnsPerHost(12)
+            ->idleTimeout(40)
+            ->connectTimeout(4)
+            ->requestTimeout(25);
+
+        self::assertInstanceOf(ClientBuilder::class, $builder);
+    }
+
+    /** @test */
+    public function userSuppliedHttpClientBypassesBuild(): void
+    {
+        $mock = $this->createMock(HttpClientInterface::class);
+        $client = (new ClientBuilder())
+            ->apiKey('k')
+            ->apiSecret('s')
+            ->maxConnsPerHost(99) // these 4 must NOT mutate $mock (§7)
+            ->idleTimeout(99)
+            ->connectTimeout(99)
+            ->requestTimeout(99)
+            ->httpClient($mock)
+            ->skipEnvLoad()
+            ->build();
+
+        self::assertSame($mock, $client->getHttpClient());
     }
 }

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -270,7 +270,7 @@ class ClientBuilderTest extends TestCase
     {
         $mock = $this->createMock(HttpClientInterface::class);
 
-        // The mock must NEVER have request() called during build() — building
+        // The mock must NEVER have request() called during build(); building
         // should be a pure construction step, no probe requests.
         $mock->expects(self::never())->method('request');
 

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -245,19 +245,24 @@ class ClientBuilderTest extends TestCase
     /** @test */
     public function poolConfigKnobsAreChained(): void
     {
-        // After Task 3 wires GuzzleHttpClient::__construct(?PoolConfig), this
-        // test will assert against $client->getHttpClient()->getPoolConfig().
-        // For now, we just assert the builder exposes the 4 fluent methods
-        // and returns $this for chaining (Task 2 scope).
-        $builder = (new ClientBuilder())
+        $client = (new ClientBuilder())
             ->apiKey('k')
             ->apiSecret('s')
             ->maxConnsPerHost(12)
             ->idleTimeout(40)
             ->connectTimeout(4)
-            ->requestTimeout(25);
+            ->requestTimeout(25)
+            ->skipEnvLoad()
+            ->build();
 
-        self::assertInstanceOf(ClientBuilder::class, $builder);
+        $http = $client->getHttpClient();
+        self::assertInstanceOf(\GetStream\Http\GuzzleHttpClient::class, $http);
+
+        $pool = $http->getPoolConfig();
+        self::assertSame(12, $pool->maxConnsPerHost);
+        self::assertSame(40, $pool->idleTimeout);
+        self::assertSame(4, $pool->connectTimeout);
+        self::assertSame(25, $pool->requestTimeout);
     }
 
     /** @test */

--- a/tests/Http/GuzzleHttpClientPoolTest.php
+++ b/tests/Http/GuzzleHttpClientPoolTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetStream\Tests\Http;
+
+use GetStream\Http\GuzzleHttpClient;
+use GetStream\Http\PoolConfig;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use PHPUnit\Framework\TestCase;
+
+class GuzzleHttpClientPoolTest extends TestCase
+{
+    /** @var array<int, array{request: \Psr\Http\Message\RequestInterface, response: \Psr\Http\Message\ResponseInterface, options: array}> */
+    private array $history = [];
+
+    /**
+     * Build a GuzzleHttpClient whose underlying handler is a MockHandler
+     * fronted by a history middleware. Records into $this->history.
+     */
+    private function buildWithHistory(?PoolConfig $pool = null, array $extraConfig = []): GuzzleHttpClient
+    {
+        $this->history = [];
+        $mock = new MockHandler([new GuzzleResponse(200, ['Content-Type' => 'application/json'], '{}')]);
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($this->history));
+
+        return new GuzzleHttpClient(
+            array_merge(['handler' => $stack], $extraConfig),
+            0,
+            $pool,
+        );
+    }
+
+    /** @test */
+    public function appliesPoolConfigToGuzzleDefaults(): void
+    {
+        $pool = new PoolConfig(maxConnsPerHost: 8, idleTimeout: 40, connectTimeout: 4, requestTimeout: 25);
+        $sdk = $this->buildWithHistory($pool);
+
+        $sdk->request('GET', 'http://example.test/');
+
+        $opts = $this->history[0]['options'];
+        self::assertSame(25, $opts['timeout'] ?? null);
+        self::assertSame(4, $opts['connect_timeout'] ?? null);
+        self::assertSame(8, $opts['curl'][CURLOPT_MAXCONNECTS] ?? null);
+    }
+
+    /** @test */
+    public function defaultsApplyWhenNoPoolConfigPassed(): void
+    {
+        $sdk = $this->buildWithHistory();
+        $sdk->request('GET', 'http://example.test/');
+
+        $opts = $this->history[0]['options'];
+        self::assertSame(30, $opts['timeout'] ?? null);
+        self::assertSame(10, $opts['connect_timeout'] ?? null);
+        self::assertSame(5, $opts['curl'][CURLOPT_MAXCONNECTS] ?? null);
+    }
+
+    /** @test */
+    public function userConfigOverridesPoolDefaults(): void
+    {
+        $pool = new PoolConfig(requestTimeout: 25);
+        $sdk = $this->buildWithHistory($pool, ['timeout' => 99]);
+
+        $sdk->request('GET', 'http://example.test/');
+        self::assertSame(99, $this->history[0]['options']['timeout'] ?? null);
+    }
+}

--- a/tests/Http/GuzzleHttpClientPoolTest.php
+++ b/tests/Http/GuzzleHttpClientPoolTest.php
@@ -46,7 +46,11 @@ class GuzzleHttpClientPoolTest extends TestCase
         $opts = $this->history[0]['options'];
         self::assertSame(25, $opts['timeout'] ?? null);
         self::assertSame(4, $opts['connect_timeout'] ?? null);
-        self::assertSame(8, $opts['curl'][CURLOPT_MAXCONNECTS] ?? null);
+        // idleTimeout is enforced via libcurl's per-connection lifetime cap (CURLOPT_MAXLIFETIME_CONN).
+        // Available since libcurl 7.80.0; if the constant is unavailable, pooling still works without it.
+        if (defined('CURLOPT_MAXLIFETIME_CONN')) {
+            self::assertSame(40, $opts['curl'][\constant('CURLOPT_MAXLIFETIME_CONN')] ?? null);
+        }
     }
 
     /** @test */
@@ -58,7 +62,33 @@ class GuzzleHttpClientPoolTest extends TestCase
         $opts = $this->history[0]['options'];
         self::assertSame(30, $opts['timeout'] ?? null);
         self::assertSame(10, $opts['connect_timeout'] ?? null);
-        self::assertSame(5, $opts['curl'][CURLOPT_MAXCONNECTS] ?? null);
+        if (defined('CURLOPT_MAXLIFETIME_CONN')) {
+            self::assertSame(55, $opts['curl'][\constant('CURLOPT_MAXLIFETIME_CONN')] ?? null);
+        }
+    }
+
+    /** @test */
+    public function defaultHandlerIsPersistentCurlMultiHandler(): void
+    {
+        // When no handler is supplied, the default stack must wrap a CurlMultiHandler
+        // so the per-host connection cap (CURLMOPT_MAX_HOST_CONNECTIONS) is real
+        // across requests in long-running runtimes.
+        $sdk = new GuzzleHttpClient([], 0, new PoolConfig());
+
+        $clientProp = (new \ReflectionObject($sdk))->getProperty('client');
+        $clientProp->setAccessible(true);
+        $guzzle = $clientProp->getValue($sdk);
+
+        $configProp = (new \ReflectionObject($guzzle))->getProperty('config');
+        $configProp->setAccessible(true);
+        $config = $configProp->getValue($guzzle);
+
+        self::assertInstanceOf(HandlerStack::class, $config['handler']);
+
+        $stack = $config['handler'];
+        $handlerProp = (new \ReflectionObject($stack))->getProperty('handler');
+        $handlerProp->setAccessible(true);
+        self::assertInstanceOf(\GuzzleHttp\Handler\CurlMultiHandler::class, $handlerProp->getValue($stack));
     }
 
     /** @test */

--- a/tests/Http/GuzzleHttpClientPoolTest.php
+++ b/tests/Http/GuzzleHttpClientPoolTest.php
@@ -70,4 +70,24 @@ class GuzzleHttpClientPoolTest extends TestCase
         $sdk->request('GET', 'http://example.test/');
         self::assertSame(99, $this->history[0]['options']['timeout'] ?? null);
     }
+
+    /** @test */
+    public function perCallTimeoutOptionReachesGuzzle(): void
+    {
+        $sdk = $this->buildWithHistory();
+        $sdk->request('GET', 'http://example.test/', [], null, ['timeout' => 2]);
+
+        self::assertSame(2, $this->history[0]['options']['timeout'] ?? null,
+            'per-call timeout reaches Guzzle request options');
+    }
+
+    /** @test */
+    public function perCallOptionOverridesClientDefault(): void
+    {
+        $sdk = $this->buildWithHistory(new PoolConfig(requestTimeout: 17));
+        $sdk->request('GET', 'http://example.test/', [], null, ['timeout' => 2]);
+
+        // Per-call 2s wins over client default 17s.
+        self::assertSame(2, $this->history[0]['options']['timeout'] ?? null);
+    }
 }

--- a/tests/Http/PoolConfigTest.php
+++ b/tests/Http/PoolConfigTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetStream\Tests\Http;
+
+use GetStream\Http\PoolConfig;
+use PHPUnit\Framework\TestCase;
+
+class PoolConfigTest extends TestCase
+{
+    /** @test */
+    public function defaultValues(): void
+    {
+        $cfg = new PoolConfig();
+
+        self::assertSame(5, $cfg->maxConnsPerHost);
+        self::assertSame(55, $cfg->idleTimeout);
+        self::assertSame(10, $cfg->connectTimeout);
+        self::assertSame(30, $cfg->requestTimeout);
+    }
+
+    /** @test */
+    public function withMaxConnsPerHostReturnsNewInstance(): void
+    {
+        $cfg = new PoolConfig();
+        $updated = $cfg->withMaxConnsPerHost(20);
+
+        self::assertNotSame($cfg, $updated, 'withers return new instances (immutability)');
+        self::assertSame(5, $cfg->maxConnsPerHost, 'original unchanged');
+        self::assertSame(20, $updated->maxConnsPerHost);
+    }
+
+    /** @test */
+    public function withAllKnobsOverridden(): void
+    {
+        $cfg = (new PoolConfig())
+            ->withMaxConnsPerHost(15)
+            ->withIdleTimeout(45)
+            ->withConnectTimeout(3)
+            ->withRequestTimeout(20);
+
+        self::assertSame(15, $cfg->maxConnsPerHost);
+        self::assertSame(45, $cfg->idleTimeout);
+        self::assertSame(3, $cfg->connectTimeout);
+        self::assertSame(20, $cfg->requestTimeout);
+    }
+}

--- a/tests/Integration/ConnectionPoolLogTest.php
+++ b/tests/Integration/ConnectionPoolLogTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetStream\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group integration
+ */
+class ConnectionPoolLogTest extends TestCase
+{
+    public function testInfoLogContainsAllKnobs(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'gs-cp-log-');
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $script = <<<PHP
+<?php
+require_once '{$autoload}';
+ini_set('error_log', \$argv[1]);
+(new GetStream\\ClientBuilder())
+    ->apiKey('k')->apiSecret('s')
+    ->maxConnsPerHost(7)->idleTimeout(33)->connectTimeout(2)->requestTimeout(11)
+    ->skipEnvLoad()
+    ->build();
+PHP;
+        $scriptPath = tempnam(sys_get_temp_dir(), 'gs-cp-script-') . '.php';
+        file_put_contents($scriptPath, $script);
+
+        $cmd = sprintf('php %s %s 2>&1', escapeshellarg($scriptPath), escapeshellarg($tmp));
+        exec($cmd, $out, $code);
+        self::assertSame(0, $code, implode("\n", $out));
+
+        $log = file_get_contents($tmp);
+        self::assertStringContainsString('max_conns_per_host=7', $log);
+        self::assertStringContainsString('idle_timeout=33s', $log);
+        self::assertStringContainsString('connect_timeout=2s', $log);
+        self::assertStringContainsString('request_timeout=11s', $log);
+        self::assertStringContainsString('user_http_client=false', $log);
+
+        @unlink($tmp);
+        @unlink($scriptPath);
+    }
+
+    public function testInfoLogIndicatesEscapeHatchUsed(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'gs-cp-log-');
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $script = <<<PHP
+<?php
+require_once '{$autoload}';
+ini_set('error_log', \$argv[1]);
+\$mock = new class implements GetStream\\Http\\HttpClientInterface {
+    public function request(string \$method, string \$url, array \$headers = [], mixed \$body = null, array \$options = []): GetStream\\StreamResponse {
+        return new GetStream\\StreamResponse(200, [], null, '');
+    }
+};
+(new GetStream\\ClientBuilder())
+    ->apiKey('k')->apiSecret('s')
+    ->httpClient(\$mock)
+    ->skipEnvLoad()
+    ->build();
+PHP;
+        $scriptPath = tempnam(sys_get_temp_dir(), 'gs-cp-script-') . '.php';
+        file_put_contents($scriptPath, $script);
+
+        $cmd = sprintf('php %s %s 2>&1', escapeshellarg($scriptPath), escapeshellarg($tmp));
+        exec($cmd, $out, $code);
+        self::assertSame(0, $code, implode("\n", $out));
+
+        $log = file_get_contents($tmp);
+        self::assertStringContainsString('user_http_client=true', $log);
+        self::assertStringContainsString('5 knobs not applied', $log);
+
+        @unlink($tmp);
+        @unlink($scriptPath);
+    }
+}

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -573,7 +573,7 @@ class WebhookTest extends TestCase
         // Per CHA-3071 wire format: decodeSqsPayload falls back to raw bytes when
         // base64 decoding fails (uncompressed wire format). For input that is
         // neither valid base64 nor valid JSON nor gzip-prefixed, parseSqs still
-        // throws InvalidWebhookException — just down the chain at JSON parsing.
+        // throws InvalidWebhookException, just down the chain at JSON parsing.
         $dir = __DIR__ . '/fixtures/webhooks/_invalid/bad_base64';
         if (!\is_dir($dir)) {
             $this->markTestSkipped('fixtures not present');

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -277,7 +277,7 @@ class WebhookTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
-    // Spec §6 helpers + composites: parseEvent, gunzipPayload, decodeSqsPayload,
+    // Webhook helpers + composites: parseEvent, gunzipPayload, decodeSqsPayload,
     // decodeSnsPayload, verifyAndParseWebhook, parseSqs, parseSns.
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds connection pool configuration to getstream-php.

- 4 new chained methods on `ClientBuilder`: `maxConnsPerHost`, `idleTimeout`, `connectTimeout`, `requestTimeout` (all `int` seconds)
- New `GetStream\Http\PoolConfig` immutable value object for the 5 canonical knobs
- `HttpClientInterface::request()` gains an optional `array $options = []` 5th param for per-call overrides (`['timeout' => N]`)
- `GuzzleHttpClient` accepts an optional `?PoolConfig` constructor arg
- Defaults: 5 / 55s / 10s / 30s
- INFO log on `build()`, `error_log()` based, quiet under PHPUnit
- `httpClient()` escape hatch unchanged: when set, none of the 4 knobs are applied

## Behavior change

None for default configuration. The pre-existing Guzzle defaults already matched (30s `timeout`, 10s `connect_timeout`). What's new is that they are tunable and an additional `MaxConnsPerHost` knob is wired through. The `Client::__construct` signature is preserved.

## Version

Bumped to v7.3.0 (v7.2.0 already shipped with the gzip work in CHA-2964).

## PHP-FPM caveat

`idleTimeout` and `maxConnsPerHost` have no effect under PHP-FPM (the curl handle dies with the request). They take effect in long-running PHP runtimes (Swoole, RoadRunner, daemons). Documented in CHANGELOG + README.

## Test plan

- [x] `PoolConfig` value-object defaults + withers
- [x] `GuzzleHttpClient` applies `PoolConfig` to Guzzle defaults; user config wins
- [x] Per-call `['timeout' => N]` reaches Guzzle via `Middleware::history`
- [x] `ClientBuilder` chained methods + end-to-end propagation
- [x] `httpClient()` escape hatch bypasses all 4 knobs
- [x] INFO log content (subprocess integration test; clean output in unit runs)
- [x] PHPStan clean at level 8
- [x] `make lint` clean

## Refs

- Linear: [CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)